### PR TITLE
Herokuデプロイ時にnpm run build を実行

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "watch-poll": "mix watch -- --watch-options-poll=1000",
         "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "mix --production"
+        "production": "mix --production",
+        "heroku-postbuild": "npm run prod"
     },
     "devDependencies": {
         "@babel/preset-react": "^7.13.13",


### PR DESCRIPTION
参考：https://devcenter.heroku.com/ja/articles/nodejs-support#customizing-the-build-process

Heroku側の Buildpacksに `heroku/nodejs` を追加する必要あり